### PR TITLE
Fix for latest ts-node

### DIFF
--- a/packages/ts-node-to/bin.js
+++ b/packages/ts-node-to/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
+var tsNodeBin = require('ts-node/dist/bin.js');
+
 // Prepend --transpile-only to args
 // We could use the environment variable, but that would leak and isn't strictly necessary.
-process.argv.splice(2, 0, '--transpile-only');
-require('ts-node/dist/bin.js');
+tsNodeBin.main(['--transpile-only'].concat(process.argv.slice(2)));

--- a/packages/ts-node-to/package.json
+++ b/packages/ts-node-to/package.json
@@ -28,7 +28,7 @@
     "ts-node": "*"
   },
   "devDependencies": {
-    "ts-node": "^8.0.1"
+    "ts-node": "^8.6.2"
   },
   "files": [
     "bin.js",
@@ -38,7 +38,7 @@
   "personalMonoRepoMeta": {
     "livesIn": "mono"
   },
-  "main": "dist/index.js",
+  "main": "dist/index",
   "types": "dist/index.d.ts",
   "npmignore": [
     ".yarnrc",


### PR DESCRIPTION
See also: TypeStrong/ts-node#939  (https://github.com/TypeStrong/ts-node/pull/939#issuecomment-575380554)

Turns out ts-node recently made a change to the `bin` script that broke ts-node-to.  This fixes the integration.